### PR TITLE
fix(base64encode): support ArrayBuffer/Uint8Array input and fix binar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Each preset is bundled independently for tree-shaking — unused presets don't i
 
 | Function | Description |
 |---|---|
-| [`$base64encode()`](#base64encode) | Encode a string to Base64 |
+| [`$base64encode()`](#base64encode) | Encode a string, ArrayBuffer, or Uint8Array to Base64 |
 | [`$base64decode()`](#base64decode) | Decode a Base64 string |
 | [`$base64ToBlob()`](#base64toblob) | Convert Base64 to a Blob |
 | [`$blob()`](#blob) | Create a Blob from content |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.1.0",
+  "version": "2.0.1",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",

--- a/src/__tests__/base64encode.test.ts
+++ b/src/__tests__/base64encode.test.ts
@@ -37,4 +37,15 @@ describe('encodebase64', () => {
     expect(result).toBe(expectedOutput)
   })
 
+  it('should encode an ArrayBuffer of binary bytes without corruption', () => {
+    // JPEG magic bytes — non-UTF-8, would be corrupted by the TextEncoder path
+    const jpegMagic = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0])
+    expect(base64encode(jpegMagic.buffer)).toBe('/9j/4A==')
+  })
+
+  it('should encode a Uint8Array of binary bytes without corruption', () => {
+    const jpegMagic = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0])
+    expect(base64encode(jpegMagic)).toBe('/9j/4A==')
+  })
+
 })

--- a/src/functions/base64encode.ts
+++ b/src/functions/base64encode.ts
@@ -1,9 +1,19 @@
-function base64encode(input: string, urlSafe = false): string {
+function base64encode(input: string | ArrayBufferLike | Uint8Array, urlSafe = false): string {
+  let bytes: Uint8Array
+  if (
+    input instanceof ArrayBuffer ||
+    (typeof SharedArrayBuffer !== 'undefined' && input instanceof SharedArrayBuffer)
+  ) {
+    bytes = new Uint8Array(input)
+  } else if (input instanceof Uint8Array) {
+    bytes = input
+  } else {
+    bytes = new TextEncoder().encode(input)
+  }
+  const CHUNK = 8192
   let binary = ''
-  const bytes = new TextEncoder().encode(input)
-  const len = bytes.length
-  for (let i = 0; i < len; i++) {
-    binary += String.fromCharCode(bytes[i])
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK))
   }
   let base64 = btoa(binary)
   if (urlSafe) {


### PR DESCRIPTION


$base64encode($getArrayBuffer(file)) was silently corrupting binary file content because TextEncoder coerced ArrayBuffer to the string "[object ArrayBuffer]".

