### PR TITLE
fix(base64encode): fix TypeScript strict mode errors in types CI step

### DIFF
--- a/src/functions/base64encode.ts
+++ b/src/functions/base64encode.ts
@@ -8,12 +8,12 @@ function base64encode(input: string | ArrayBufferLike | Uint8Array, urlSafe = fa
   } else if (input instanceof Uint8Array) {
     bytes = input
   } else {
-    bytes = new TextEncoder().encode(input)
+    bytes = new TextEncoder().encode(input as string)
   }
   const CHUNK = 8192
   let binary = ''
   for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK))
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + CHUNK)))
   }
   let base64 = btoa(binary)
   if (urlSafe) {


### PR DESCRIPTION
- Cast input as string in else branch — TypeScript cannot fully narrow SharedArrayBuffer out via typeof guard, leaving string | SharedArrayBuffer which TextEncoder.encode() rejects under strict mode
- Replace String.fromCharCode.apply(null, Uint8Array) with Array.from() so the argument is number[] as strictBindCallApply requires