### PR TITLE
fix: null-safe $each and $sift overrides for jsonata 2.2 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",

--- a/src/__tests__/jsonata22Prototype.compat.test.ts
+++ b/src/__tests__/jsonata22Prototype.compat.test.ts
@@ -107,6 +107,79 @@ describe('parseUrl JSONata 2.2', () => {
   })
 })
 
+describe('$each null-safety (jsonata 2.2 regression)', () => {
+  it('returns undefined for $each(undefined, fn)', async () => {
+    const expr = trutoJsonata('$each(missing, function($v,$k){$v})')
+    await expect(expr.evaluate({})).resolves.toBeUndefined()
+  })
+
+  it('returns undefined for $each on null-valued field', async () => {
+    const expr = trutoJsonata('$each(x, function($v,$k){$v})')
+    await expect(expr.evaluate({ x: null })).resolves.toBeUndefined()
+  })
+
+  it('works normally for a single-entry object', async () => {
+    const expr = trutoJsonata('$each({"a":1}, function($v,$k){$v})')
+    await expect(expr.evaluate({})).resolves.toBe(1)
+  })
+
+  it('works normally for a multi-entry object', async () => {
+    const expr = trutoJsonata(
+      '$each({"a":1,"b":2}, function($v,$k){$string($v)})'
+    )
+    const result = await expr.evaluate({})
+    expect(result).toEqual(['1', '2'])
+  })
+
+  it('handles the production ternary pattern: $type(x)="string" ? ... : $each(x, fn)', async () => {
+    const expression = `$type(created_at) = "string"
+      ? { "op": "GT", "val": created_at }
+      : $each(created_at, function($v, $k) { { "op": $uppercase($k), "val": $v } })`
+
+    const absent = trutoJsonata(expression)
+    await expect(absent.evaluate({})).resolves.toBeUndefined()
+
+    const str = trutoJsonata(expression)
+    await expect(str.evaluate({ created_at: '2024-01-01' })).resolves.toEqual({
+      op: 'GT',
+      val: '2024-01-01',
+    })
+
+    const obj = trutoJsonata(expression)
+    const result = await obj.evaluate({
+      created_at: { gt: '2024-01-01', lt: '2024-12-31' },
+    })
+    expect(result).toEqual([
+      { op: 'GT', val: '2024-01-01' },
+      { op: 'LT', val: '2024-12-31' },
+    ])
+  })
+})
+
+describe('$sift null-safety (jsonata 2.2 regression)', () => {
+  it('returns undefined for $sift(undefined, fn)', async () => {
+    const expr = trutoJsonata('$sift(missing, function($v){$v})')
+    await expect(expr.evaluate({})).resolves.toBeUndefined()
+  })
+
+  it('returns undefined for $sift on null-valued field', async () => {
+    const expr = trutoJsonata('$sift(x, function($v){$v})')
+    await expect(expr.evaluate({ x: null })).resolves.toBeUndefined()
+  })
+
+  it('returns undefined for $sift on empty object', async () => {
+    const expr = trutoJsonata('$sift({}, function($v){$v})')
+    await expect(expr.evaluate({})).resolves.toBeUndefined()
+  })
+
+  it('filters object entries normally', async () => {
+    const expr = trutoJsonata(
+      '$sift({"a":1,"b":0,"c":2}, function($v){$v > 0})'
+    )
+    await expect(expr.evaluate({})).resolves.toEqual({ a: 1, c: 2 })
+  })
+})
+
 describe('Production unified-mapping datetime snippets', () => {
   it.each(mappingCases)('$name', async ({ expression, bindings, expectType }) => {
     const expr = trutoJsonata(expression)

--- a/src/presets/core.ts
+++ b/src/presets/core.ts
@@ -84,6 +84,44 @@ export function registerCoreExtensions(expression: Expression): Expression {
   expression.registerFunction('uuid', uuid)
   expression.registerFunction('zipSqlResponse', zipSqlResponse)
 
+  // jsonata 2.2 changed $each and $sift to throw on undefined instead of
+  // returning undefined. Override with null-safe versions to preserve compat.
+  expression.registerFunction(
+    'each',
+    async function (
+      obj: Record<string, unknown> | undefined | null,
+      func: (...args: unknown[]) => unknown
+    ) {
+      if (obj === undefined || obj === null) return undefined
+      const result: unknown[] = []
+      for (const key of Object.keys(obj)) {
+        const val = await func(obj[key], key, obj)
+        if (val !== undefined) result.push(val)
+      }
+      return result.length === 0
+        ? undefined
+        : result.length === 1
+          ? result[0]
+          : result
+    }
+  )
+
+  expression.registerFunction(
+    'sift',
+    async function (
+      obj: Record<string, unknown> | undefined | null,
+      func: (...args: unknown[]) => unknown
+    ) {
+      if (obj === undefined || obj === null) return undefined
+      const result: Record<string, unknown> = {}
+      for (const key of Object.keys(obj)) {
+        const keep = await func(obj[key], key, obj)
+        if (keep) result[key] = obj[key]
+      }
+      return Object.keys(result).length === 0 ? undefined : result
+    }
+  )
+
   // lodash wrappers
   expression.registerFunction('groupBy', function (array: any, key: any) {
     return groupBy(castArray(array), key)


### PR DESCRIPTION
## Summary

- jsonata 2.2.1 (CVE-2026-12208 fix, [PR #799](https://github.com/jsonata-js/jsonata/pull/799)) changed all `for..in` loops to `for..of Object.keys()` to prevent prototype pollution. This inadvertently broke `$each(undefined, fn)` and `$sift(undefined, fn)` — they now throw `Cannot convert undefined or null to object` instead of returning `undefined`.
- Override both built-ins with null-safe versions in `registerCoreExtensions` that restore the pre-2.2 behavior.
- Bump version 3.0.0 → 3.0.1.

**Affected production usage**: 115 `$each` + 41 `$sift` call sites across unified-model YAML mappings.

## Test plan

- [x] 9 new tests covering `$each` and `$sift` with undefined, null, empty object, single-entry, multi-entry, and the production ternary pattern
- [x] Full test suite passes (507 tests, 51 files)