### PR TITLE
fix(jsonToParquet): fail loudly on empty or invalid Parquet output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,7 +1103,7 @@ Converts a single object or an array of objects to **Apache Parquet** and return
 
 **Input**
 
-- **rows**: One `Record` or an array of records. `null` / `undefined` entries in an array are removed. If nothing is left, the result is an empty `ArrayBuffer`.
+- **rows**: One `Record` or an array of records. `null` / `undefined` entries in an array are removed. **At least one record with at least one field is required** — if nothing is left to encode, `$jsonToParquet` throws rather than returning an empty (and therefore corrupt) file.
 - **options** _(optional)_: Only the fields below are passed through; anything else is ignored. Omitted keys use [hyparquet-writer defaults](https://github.com/hyparam/hyparquet-writer) (for example default compression).
 
 | Option | Type | Description |
@@ -1112,6 +1112,10 @@ Converts a single object or an array of objects to **Apache Parquet** and return
 | **rowGroupSize** | `number` \| `number[]` | Rows per row group. A single number fixes the size; an array can define a tiered layout (see hyparquet-writer `ParquetWriteOptions`). |
 
 Nested objects and arrays are stored with Parquet’s **JSON** logical type (UTF-8 JSON text). Primitive columns are inferred where possible (`BOOLEAN`, `INT32` / `INT64` / `DOUBLE`, `STRING`, timestamps for `Date`, etc.).
+
+**Output validation:** Before returning, `$jsonToParquet` verifies that the encoded bytes are a structurally valid Parquet file — a non-empty body that begins and ends with the `PAR1` magic markers and carries a footer whose declared metadata length fits the body. If the check fails (empty body, truncated or corrupt output), it **throws a descriptive error instead of returning invalid bytes**, so a corrupt file is never handed back for upload or storage. Because the guarantee lives inside the function, it applies everywhere `$jsonToParquet` is evaluated — sync job V4 transforms, workflows, unified/mapping expressions, tests and CLI tooling — and each caller surfaces the failure through its own error handling.
+
+This is intentionally stricter than [`$jsonToCsv`](#jsontocsv), which returns an empty string for empty input: an empty CSV is still a valid file, whereas an empty Parquet file has no valid structure and would be rejected downstream. Guard possibly-empty inputs at the call site (for example `$count($rows) = 0 ? null : $jsonToParquet($rows)`) when you want to skip rather than fail.
 
 **Example:**
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",

--- a/src/functions/__tests__/jsonToParquet.test.ts
+++ b/src/functions/__tests__/jsonToParquet.test.ts
@@ -1,7 +1,26 @@
 import { parquetReadObjects } from 'hyparquet'
-import { describe, expect, it } from 'vitest'
+import { parquetWriteBuffer } from 'hyparquet-writer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import jsonToParquet from '../jsonToParquet'
+import trutoJsonata from '../../index'
 import { unwrapArrayBuffer } from '../unwrapNative'
+
+// A controllable override so a single test can force the underlying writer to
+// emit bad bytes, while every other test transparently uses the real writer.
+const writerControl = vi.hoisted(() => ({
+  override: null as ArrayBuffer | null,
+}))
+
+vi.mock('hyparquet-writer', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('hyparquet-writer')>()
+  return {
+    ...actual,
+    parquetWriteBuffer: (
+      options: Parameters<typeof actual.parquetWriteBuffer>[0]
+    ): ArrayBuffer =>
+      writerControl.override ?? actual.parquetWriteBuffer(options),
+  }
+})
 
 function expectParquetMagic(buf: unknown) {
   const native = unwrapArrayBuffer(buf)
@@ -19,32 +38,41 @@ function expectParquetMagic(buf: unknown) {
 describe('jsonToParquet', () => {
   const baseOpts = { codec: 'UNCOMPRESSED' as const }
 
-  describe('empty inputs', () => {
-    it('returns empty ArrayBuffer for empty array', () => {
-      const buf = jsonToParquet([], baseOpts)
-      expect(buf.byteLength).toBe(0)
-      expect(unwrapArrayBuffer(buf)?.byteLength).toBe(0)
+  afterEach(() => {
+    writerControl.override = null
+  })
+
+  describe('empty / column-less input throws', () => {
+    it('throws for an empty array', () => {
+      expect(() => jsonToParquet([], baseOpts)).toThrow(/no rows to encode/)
     })
 
-    it('returns empty ArrayBuffer for null', () => {
-      const buf = jsonToParquet(null as unknown as Record<string, unknown>[], baseOpts)
-      expect(buf.byteLength).toBe(0)
+    it('throws for null', () => {
+      expect(() =>
+        jsonToParquet(null as unknown as Record<string, unknown>[], baseOpts)
+      ).toThrow(/no rows to encode/)
     })
 
-    it('returns empty ArrayBuffer for undefined', () => {
-      const buf = jsonToParquet(
-        undefined as unknown as Record<string, unknown>[],
-        baseOpts
-      )
-      expect(buf.byteLength).toBe(0)
+    it('throws for undefined', () => {
+      expect(() =>
+        jsonToParquet(
+          undefined as unknown as Record<string, unknown>[],
+          baseOpts
+        )
+      ).toThrow(/no rows to encode/)
     })
 
-    it('returns empty ArrayBuffer when compact removes all rows', () => {
-      const buf = jsonToParquet(
-        [null, undefined] as unknown as Record<string, unknown>[],
-        baseOpts
-      )
-      expect(buf.byteLength).toBe(0)
+    it('throws when compact removes all rows', () => {
+      expect(() =>
+        jsonToParquet(
+          [null, undefined] as unknown as Record<string, unknown>[],
+          baseOpts
+        )
+      ).toThrow(/no rows to encode/)
+    })
+
+    it('throws when the rows have no columns', () => {
+      expect(() => jsonToParquet([{}, {}], baseOpts)).toThrow(/no columns/)
     })
   })
 
@@ -119,6 +147,74 @@ describe('jsonToParquet', () => {
       const buf = jsonToParquet([{ x: 1 }], {
         ...baseOpts,
         rowGroupSize: 500,
+      })
+      expectParquetMagic(buf)
+    })
+  })
+
+  // The writer is forced to return invalid bytes so we can prove jsonToParquet
+  // validates its own output instead of returning whatever the writer emits.
+  describe('output validation', () => {
+    it('throws "empty body" when the writer returns a zero-length buffer', () => {
+      writerControl.override = new ArrayBuffer(0)
+      expect(() => jsonToParquet([{ a: 1 }], baseOpts)).toThrow(/empty body/)
+    })
+
+    it('throws "too small" when the writer returns a runt buffer', () => {
+      writerControl.override = new ArrayBuffer(6)
+      expect(() => jsonToParquet([{ a: 1 }], baseOpts)).toThrow(/too small/)
+    })
+
+    it('throws "invalid Parquet structure" when the magic markers are missing', () => {
+      // 32 non-empty bytes with no PAR1 markers.
+      writerControl.override = new ArrayBuffer(32)
+      expect(() => jsonToParquet([{ a: 1 }], baseOpts)).toThrow(
+        /invalid Parquet structure/
+      )
+    })
+
+    it('throws when real writer output is truncated', () => {
+      // Built with override still null, so this uses the real writer.
+      const good = parquetWriteBuffer({
+        columnData: [{ name: 'a', data: [1, 2, 3], type: 'INT32' }],
+      })
+      writerControl.override = good.slice(0, good.byteLength - 2)
+      expect(() => jsonToParquet([{ a: 1 }], baseOpts)).toThrow()
+    })
+
+    it('throws "corrupt Parquet footer" when the footer length overruns the body', () => {
+      // Valid PAR1 envelope but a footer length far larger than the body.
+      const buf = new ArrayBuffer(20)
+      const u8 = new Uint8Array(buf)
+      const view = new DataView(buf)
+      u8.set([0x50, 0x41, 0x52, 0x31], 0) // "PAR1" header
+      u8.set([0x50, 0x41, 0x52, 0x31], 16) // "PAR1" footer
+      view.setUint32(12, 0xffffffff, true) // absurd footer metadata length
+      writerControl.override = buf
+      expect(() => jsonToParquet([{ a: 1 }], baseOpts)).toThrow(
+        /corrupt Parquet footer/
+      )
+    })
+
+    it('returns the bytes unchanged when the writer output is valid', () => {
+      const buf = jsonToParquet([{ a: 1 }, { a: 2 }], baseOpts)
+      expectParquetMagic(buf)
+    })
+  })
+
+  // Exercised through the real trutoJsonata entrypoint the way production does
+  // ($jsonToParquet inside an evaluated expression), not just the raw function,
+  // to lock in that failures propagate as a rejected evaluate() promise.
+  describe('JSONata evaluation path', () => {
+    it('rejects the evaluated expression when the input is empty', async () => {
+      await expect(
+        trutoJsonata('$jsonToParquet(rows)').evaluate({ rows: [] })
+      ).rejects.toThrow(/no rows to encode/)
+    })
+
+    it('returns a valid Parquet ArrayBuffer from an evaluated expression', async () => {
+      const buf = await trutoJsonata('$jsonToParquet(rows)').evaluate({
+        rows: [{ a: 1 }, { a: 2 }],
       })
       expectParquetMagic(buf)
     })

--- a/src/functions/jsonToParquet.ts
+++ b/src/functions/jsonToParquet.ts
@@ -134,6 +134,71 @@ function columnSourceFor(
   }
 }
 
+const PARQUET_MAGIC = 'PAR1'
+// A well-formed Parquet file is at minimum a "PAR1" header (4 bytes) + the
+// footer metadata length as an int32 (4 bytes) + a "PAR1" footer (4 bytes).
+const PARQUET_MIN_BYTES = 12
+
+function readMagic(bytes: Uint8Array, start: number): string {
+  return String.fromCharCode(
+    bytes[start],
+    bytes[start + 1],
+    bytes[start + 2],
+    bytes[start + 3]
+  )
+}
+
+/**
+ * Verify that `buffer` looks like a structurally valid Parquet file before it
+ * is handed back to a caller. A valid file is a non-empty body that opens and
+ * closes with the `PAR1` magic markers and declares a footer-metadata length
+ * that fits within the body. Anything else (an empty body, truncated/garbage
+ * bytes, a corrupt footer) throws a descriptive error instead of being
+ * returned, so no caller uploads or persists a broken Parquet object.
+ *
+ * This is an intentionally cheap structural check — it does not parse the
+ * thrift footer — which keeps it dependency-free and safe to run on every
+ * write in Cloudflare Workers and other hot paths.
+ */
+function assertValidParquet(buffer: ArrayBuffer): void {
+  if (!(buffer instanceof ArrayBuffer)) {
+    throw new Error(
+      '$jsonToParquet expected the Parquet writer to return an ArrayBuffer but it did not'
+    )
+  }
+  if (buffer.byteLength === 0) {
+    throw new Error(
+      '$jsonToParquet produced an empty body; refusing to return invalid Parquet bytes'
+    )
+  }
+  if (buffer.byteLength < PARQUET_MIN_BYTES) {
+    throw new Error(
+      `$jsonToParquet produced only ${buffer.byteLength} bytes, too small to be a valid Parquet file`
+    )
+  }
+
+  const bytes = new Uint8Array(buffer)
+  const header = readMagic(bytes, 0)
+  const footer = readMagic(bytes, buffer.byteLength - 4)
+  if (header !== PARQUET_MAGIC || footer !== PARQUET_MAGIC) {
+    throw new Error(
+      `$jsonToParquet produced an invalid Parquet structure; expected "PAR1" magic markers but found header="${header}", footer="${footer}"`
+    )
+  }
+
+  // The 4 bytes immediately before the trailing magic hold the footer metadata
+  // length (little-endian int32). It must be positive and fit inside the body.
+  const footerLength = new DataView(buffer).getUint32(
+    buffer.byteLength - 8,
+    true
+  )
+  if (footerLength <= 0 || footerLength + PARQUET_MIN_BYTES > buffer.byteLength) {
+    throw new Error(
+      `$jsonToParquet produced a corrupt Parquet footer; declared metadata length ${footerLength} does not fit within ${buffer.byteLength} bytes`
+    )
+  }
+}
+
 export default function jsonToParquet(
   json: Record<string, unknown> | Record<string, unknown>[],
   options?: JsonToParquetOptions | Record<string, unknown>
@@ -142,10 +207,18 @@ export default function jsonToParquet(
     castArray(json)
   ) as Record<string, unknown>[]
   if (isEmpty(jsonArray)) {
-    return toJsonataArrayBuffer(new ArrayBuffer(0))
+    throw new Error(
+      '$jsonToParquet received no rows to encode; a valid Parquet file requires at least one record'
+    )
   }
 
   const names = collectColumnNames(jsonArray)
+  if (isEmpty(names)) {
+    throw new Error(
+      '$jsonToParquet received rows with no columns; a valid Parquet file requires at least one field'
+    )
+  }
+
   const columnData = map(names, (col) =>
     columnSourceFor(
       col,
@@ -154,13 +227,14 @@ export default function jsonToParquet(
   )
 
   const opts = (options ?? {}) as JsonToParquetOptions
-  return toJsonataArrayBuffer(
-    parquetWriteBuffer({
-      columnData,
-      ...(opts.codec !== undefined ? { codec: opts.codec } : {}),
-      ...(opts.rowGroupSize !== undefined
-        ? { rowGroupSize: opts.rowGroupSize }
-        : {}),
-    })
-  )
+  const buffer = parquetWriteBuffer({
+    columnData,
+    ...(opts.codec !== undefined ? { codec: opts.codec } : {}),
+    ...(opts.rowGroupSize !== undefined
+      ? { rowGroupSize: opts.rowGroupSize }
+      : {}),
+  })
+
+  assertValidParquet(buffer)
+  return toJsonataArrayBuffer(buffer)
 }


### PR DESCRIPTION
## Summary
- `$jsonToParquet` now throws on empty input or rows with no columns instead of returning a corrupt empty file
- After writing, it validates the output bytes have valid Parquet structure (`PAR1` header/footer and sane footer length) before returning
- Adds tests for input validation, output validation, and JSONata evaluation path; bumps version to 3.0.2

## Test plan
- [x] `npm test -- src/functions/__tests__/jsonToParquet.test.ts` (20 tests pass)
- [ ] Confirm sync jobs that call `$jsonToParquet` already guard empty batches before calling it


Made with [Cursor](https://cursor.com)