### PR TITLE
fix: export native helpers and restore JSONata parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",

--- a/src/__tests__/eachSiftBuiltinParity.test.ts
+++ b/src/__tests__/eachSiftBuiltinParity.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { evalCore } from './helpers/jsonataEval'
+
+// The $each/$sift overrides (null-safety for jsonata 2.2) must otherwise
+// behave exactly like the jsonata 2.0 builtins they replace. These are the
+// regressions the first override version introduced.
+describe('$each/$sift builtin parity', () => {
+  describe('context injection (`data.$fn(callback)` idiom)', () => {
+    it('injects the context value as $sift input', async () => {
+      const result = await evalCore('o.$sift(function($v) { $v > 1 })', {
+        o: { a: 1, b: 2 },
+      })
+      expect(result).toEqual({ b: 2 })
+    })
+
+    it('injects the context value as $each input', async () => {
+      const result = await evalCore(
+        'o.$each(function($v, $k) { $k & "=" & $v })',
+        { o: { a: 1, b: 2 } }
+      )
+      expect(result).toEqual(['a=1', 'b=2'])
+    })
+
+    it('supports the documented $sift key-predicate idiom', async () => {
+      const result = await evalCore(
+        'o.$sift(function($v, $k) { $k ~> /^ke/ })',
+        { o: { keep: 1, drop: 2 } }
+      )
+      expect(result).toEqual({ keep: 1 })
+    })
+  })
+
+  describe('callback arity handling', () => {
+    it('accepts signatured single-arg callbacks in $each', async () => {
+      const result = await evalCore('$each(o, $string)', { o: { a: 1, b: 2 } })
+      expect(result).toEqual(['1', '2'])
+    })
+
+    it('accepts signatured single-arg callbacks in $sift', async () => {
+      const result = await evalCore('$sift(o, $boolean)', {
+        o: { a: 0, b: 2 },
+      })
+      expect(result).toEqual({ b: 2 })
+    })
+
+    it('still passes key and object to callbacks that declare them', async () => {
+      const result = await evalCore(
+        '$each(o, function($v, $k, $o) { $k & ":" & $v & "/" & $count($keys($o)) })',
+        { o: { a: 1, b: 2 } }
+      )
+      expect(result).toEqual(['a:1/2', 'b:2/2'])
+    })
+  })
+
+  describe('$sift effective-boolean semantics', () => {
+    it('drops entries whose predicate is an empty array or empty object', async () => {
+      const result = await evalCore('$sift(o, function($v) { $v })', {
+        o: { emptyArr: [], str: 'x', zero: 0, arr: [1], emptyObj: {} },
+      })
+      expect(result).toEqual({ str: 'x', arr: [1] })
+    })
+
+    it('treats an array with any truthy member as true', async () => {
+      const result = await evalCore('$sift(o, function($v) { $v })', {
+        o: { mixed: [0, 1], allFalsy: [0, ''] },
+      })
+      expect(result).toEqual({ mixed: [0, 1] })
+    })
+
+    it('throws D1001 for non-finite predicate values like the builtins', async () => {
+      // Both jsonata 2.0 and 2.2 builtins throw D1001 (isNumeric) when the
+      // predicate result is ±Infinity — a silent drop would hide the error.
+      await expect(
+        evalCore('$sift(o, function($v) { $v })', { o: { a: 1e309 } })
+      ).rejects.toMatchObject({ code: 'D1001' })
+    })
+
+    it('keeps entries whose predicate is a function value, like the 2.0 builtin', async () => {
+      // jsonata 2.0's boolean() had no isFunction exclusion, so a lambda
+      // predicate result (a plain object internally) counted as truthy; 2.2
+      // flipped this, but 2.0 is the parity target.
+      const result = await evalCore(
+        '$sift(o, function($v) { function($x){$x} })',
+        { o: { a: 1, b: 2 } }
+      )
+      expect(result).toEqual({ a: 1, b: 2 })
+    })
+  })
+
+  describe('null-safety (the reason for the overrides)', () => {
+    it('$each returns undefined for missing input', async () => {
+      expect(
+        await evalCore('$each(o.missing, function($v) { $v })', { o: {} })
+      ).toBeUndefined()
+    })
+
+    it('$sift returns undefined for missing input', async () => {
+      expect(
+        await evalCore('$sift(o.missing, function($v) { $v })', { o: {} })
+      ).toBeUndefined()
+    })
+  })
+
+  describe('builtin result-shape parity', () => {
+    it('$each unwraps a single result like a singleton sequence', async () => {
+      expect(
+        await evalCore('$each(o, function($v, $k) { $k = "a" ? $v })', {
+          o: { a: 42, b: 2 },
+        })
+      ).toBe(42)
+    })
+
+    it('$sift returns undefined when nothing survives', async () => {
+      expect(
+        await evalCore('$sift(o, function($v) { $v > 10 })', {
+          o: { a: 1 },
+        })
+      ).toBeUndefined()
+    })
+  })
+})

--- a/src/__tests__/jsonata22Prototype.compat.test.ts
+++ b/src/__tests__/jsonata22Prototype.compat.test.ts
@@ -113,9 +113,15 @@ describe('$each null-safety (jsonata 2.2 regression)', () => {
     await expect(expr.evaluate({})).resolves.toBeUndefined()
   })
 
-  it('returns undefined for $each on null-valued field', async () => {
+  it('rejects $each on null-valued field like the 2.0 builtin (T0410)', async () => {
+    // The jsonata 2.0 builtin threw T0410 for explicit null (signature
+    // validation rejects null for the `o` parameter); only *undefined* passed
+    // through gracefully. Matching that keeps upgrade behavior identical to
+    // what production mappings ran against.
     const expr = trutoJsonata('$each(x, function($v,$k){$v})')
-    await expect(expr.evaluate({ x: null })).resolves.toBeUndefined()
+    await expect(expr.evaluate({ x: null })).rejects.toMatchObject({
+      code: 'T0410',
+    })
   })
 
   it('works normally for a single-entry object', async () => {
@@ -162,9 +168,12 @@ describe('$sift null-safety (jsonata 2.2 regression)', () => {
     await expect(expr.evaluate({})).resolves.toBeUndefined()
   })
 
-  it('returns undefined for $sift on null-valued field', async () => {
+  it('rejects $sift on null-valued field like the 2.0 builtin (T0410)', async () => {
+    // Same builtin-parity rationale as the $each null test above.
     const expr = trutoJsonata('$sift(x, function($v){$v})')
-    await expect(expr.evaluate({ x: null })).resolves.toBeUndefined()
+    await expect(expr.evaluate({ x: null })).rejects.toMatchObject({
+      code: 'T0410',
+    })
   })
 
   it('returns undefined for $sift on empty object', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,23 @@ import registerJsonataExtensions from './registerJsonataExtensions'
 export default function trutoJsonata(expression: string): Expression {
   return registerJsonataExtensions(jsonata(expression))
 }
+
+// Native values returned by custom functions (ArrayBuffer, Blob, ReadableStream,
+// DepGraph, luxon DateTime, URL) are boxed in JSONata-safe wrappers so they
+// survive JSONata 2.2 evaluation. Consumers that need the real native value
+// back — e.g. the Truto worker uploading `$jsonToParquet(...)` bytes to S3/GCS —
+// must unwrap the evaluation result with these helpers.
+export {
+  unwrapNative,
+  unwrapArrayBuffer,
+  unwrapBlob,
+  unwrapReadableStream,
+  unwrapDepGraph,
+  unwrapDateTime,
+  unwrapUrl,
+} from './functions/unwrapNative'
+
+// Inverse direction: hosts that pass a native URL *into* an evaluation input
+// need the same JSONata-safe shape $parseUrl produces (JSONata 2.2+ cannot
+// read prototype getters, so a raw URL instance is opaque to expressions).
+export { toJsonataUrl } from './functions/parseUrl'

--- a/src/presets/core.ts
+++ b/src/presets/core.ts
@@ -47,6 +47,66 @@ import toNumber from '../functions/toNumber'
 import uuid from '../functions/uuid'
 import zipSqlResponse from '../functions/zipSqlResponse'
 
+// Callbacks reach registered functions as jsonata-wrapped JS functions
+// carrying the declared parameter count in `arity` (lambdas) or
+// `implementation.length` (registered functions). `length` on the wrapper
+// itself is always 0, so it is only a last-resort fallback.
+type JsonataCallback = ((...args: unknown[]) => unknown) & {
+  arity?: number
+  implementation?: (...args: unknown[]) => unknown
+}
+
+function callbackArity(func: JsonataCallback): number {
+  if (typeof func.arity === 'number') return func.arity
+  if (typeof func.implementation === 'function') {
+    return func.implementation.length
+  }
+  return func.length
+}
+
+// Mirror of jsonata's internal hofFuncArgs: the value is always passed, the
+// key and the whole object only if the callback declares those parameters.
+// The arity is constant per $each/$sift call, so callers compute it once and
+// pass it in instead of re-probing the callback for every key.
+function callbackArgs(
+  arity: number,
+  value: unknown,
+  key: string,
+  obj: Record<string, unknown>
+): unknown[] {
+  const args: unknown[] = [value]
+  if (arity >= 2) args.push(key)
+  if (arity >= 3) args.push(obj)
+  return args
+}
+
+// Mirror of jsonata 2.0's internal boolean(): the effective boolean value the
+// builtin $sift applied to predicate results. Notably: function-shaped values
+// (jsonata lambdas are plain objects) hit the object branch and count as
+// truthy — that matches the 2.0 builtin, which had no isFunction exclusion —
+// and non-finite numbers throw D1001 exactly like jsonata's isNumeric().
+function effectiveBoolean(arg: unknown): boolean {
+  if (arg === undefined || arg === null) return false
+  if (Array.isArray(arg)) return arg.some(effectiveBoolean)
+  switch (typeof arg) {
+    case 'boolean':
+      return arg
+    case 'string':
+      return arg.length > 0
+    case 'number':
+      if (Number.isNaN(arg)) return false
+      if (!Number.isFinite(arg)) {
+        throw { code: 'D1001', stack: new Error().stack, value: arg }
+      }
+      return arg !== 0
+    case 'object':
+      return Object.keys(arg).length > 0
+    default:
+      // real JS functions and anything exotic
+      return false
+  }
+}
+
 export function registerCoreExtensions(expression: Expression): Expression {
   expression.registerFunction('base64decode', base64decode)
   expression.registerFunction('base64encode', base64encode)
@@ -85,17 +145,27 @@ export function registerCoreExtensions(expression: Expression): Expression {
   expression.registerFunction('zipSqlResponse', zipSqlResponse)
 
   // jsonata 2.2 changed $each and $sift to throw on undefined instead of
-  // returning undefined. Override with null-safe versions to preserve compat.
+  // returning undefined. Override with undefined-safe versions that otherwise
+  // replicate the 2.0 builtins exactly:
+  // - registered with the builtin signatures so the context-injection idiom
+  //   (`payload.$sift(function($v, $k) {...})`) keeps working — explicit null
+  //   input is rejected by signature validation with T0410 before the body
+  //   runs, matching the builtin (see the compat tests),
+  // - callback args trimmed to the callback's arity so signatured callbacks
+  //   (`$each(obj, $string)`) don't throw T0410,
+  // - $sift keeps entries per JSONata effective-boolean semantics ($boolean),
+  //   not JS truthiness, so e.g. empty arrays/objects are still dropped.
   expression.registerFunction(
     'each',
     async function (
-      obj: Record<string, unknown> | undefined | null,
-      func: (...args: unknown[]) => unknown
+      obj: Record<string, unknown> | undefined,
+      func: JsonataCallback
     ) {
-      if (obj === undefined || obj === null) return undefined
+      if (obj === undefined) return undefined
+      const arity = callbackArity(func)
       const result: unknown[] = []
       for (const key of Object.keys(obj)) {
-        const val = await func(obj[key], key, obj)
+        const val = await func(...callbackArgs(arity, obj[key], key, obj))
         if (val !== undefined) result.push(val)
       }
       return result.length === 0
@@ -103,23 +173,26 @@ export function registerCoreExtensions(expression: Expression): Expression {
         : result.length === 1
           ? result[0]
           : result
-    }
+    },
+    '<o-f:a>'
   )
 
   expression.registerFunction(
     'sift',
     async function (
-      obj: Record<string, unknown> | undefined | null,
-      func: (...args: unknown[]) => unknown
+      obj: Record<string, unknown> | undefined,
+      func: JsonataCallback
     ) {
-      if (obj === undefined || obj === null) return undefined
+      if (obj === undefined) return undefined
+      const arity = callbackArity(func)
       const result: Record<string, unknown> = {}
       for (const key of Object.keys(obj)) {
-        const keep = await func(obj[key], key, obj)
-        if (keep) result[key] = obj[key]
+        const keep = await func(...callbackArgs(arity, obj[key], key, obj))
+        if (effectiveBoolean(keep)) result[key] = obj[key]
       }
       return Object.keys(result).length === 0 ? undefined : result
-    }
+    },
+    '<o-f?:o>'
   )
 
   // lodash wrappers


### PR DESCRIPTION
## Summary
- export native unwrap helpers and `toJsonataUrl` for host apps that need real native values after JSONata 2.2 evaluation
- restore `$each` / `$sift` behavior for missing inputs, callback arity, context injection, and JSONata boolean semantics
- keep `$jsonToParquet` from returning invalid empty/corrupt Parquet bytes and bump package version to 3.0.3

## Tests
- `yarn vitest run src/functions/__tests__/jsonToParquet.test.ts src/__tests__/jsonata22Prototype.compat.test.ts src/__tests__/eachSiftBuiltinParity.test.ts`
- `yarn build`