### PR TITLE
feat: mirror native inputs & unwrap native results at the evaluate boundary (v3.0.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,50 @@ registerJsonataExtensions(expression);
 // Now you can use custom functions in your expression
 ```
 
+### Native values and the host boundary (v3.0.4+)
+
+JSONata 2.2 (used since `truto-jsonata` 3.0) changed two things that matter when
+native values (`URL`, `Response`, `File`, `Blob`, `ArrayBuffer`, Luxon
+`DateTime`) cross an expression:
+
+1. **Property lookup is own-property-only.** A live `URL`/`Response`/`Blob`
+   exposes its fields through prototype getters, so `url.pathname` or
+   `response.status` read as `undefined` inside an expression.
+2. **Custom functions box the natives they return.** `$parseUrl`, `$blob`,
+   `$jsonToParquet`, `$dtFromIso`, `$getArrayBuffer`, `$teeStream`, … hand back a
+   JSONata-safe *wrapper* so the value is readable inside expressions. Left
+   as-is once the result leaves JSONata, that wrapper fails `instanceof`, breaks
+   `structuredClone` (its function props are not cloneable), and serialises to
+   `"[object Object]"`.
+
+The default entrypoint handles both for you. **`trutoJsonata(expr).evaluate(input, bindings)`** transparently:
+
+- **mirrors native inputs** on the way in, so expressions can read
+  `url.pathname`, `response.status`, `body.file.name`, `buffer.byteLength`,
+  etc. (deep — natives nested in the input object/array are handled; the input
+  is not mutated except for in-place, non-destructive stamping of
+  `Blob`/`File`/`ArrayBuffer`), and
+- **unwraps native results** on the way out, so callers get back real
+  `ArrayBuffer`/`Blob`/`URL`/`DateTime` instances that satisfy `instanceof`,
+  survive `structuredClone`/`cloneDeep`, and serialise as they did before 3.x.
+
+```javascript
+import trutoJsonata from '@truto/truto-jsonata'
+
+// input mirroring — a live URL is readable:
+await trutoJsonata('u.pathname').evaluate({ u: new URL('https://a.com/p/q') })
+// → '/p/q'
+
+// output unwrapping — a real ArrayBuffer, not a wrapper:
+const buf = await trutoJsonata('$jsonToParquet(rows)').evaluate({ rows })
+buf instanceof ArrayBuffer // → true
+structuredClone(buf)       // → ok (no DataCloneError)
+```
+
+Host apps only need to bump the version — no per-call-site changes. The boundary
+applies to the **default entrypoint only**; a raw `jsonata()` expression wired up
+with `registerJsonataExtensions` or a preset does not get it.
+
 ### Tree-Shakeable Presets (v2.0+)
 
 For smaller bundles, import only the presets you need. Each preset is independent and can be composed:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",

--- a/src/__tests__/hostNativeBoundary.test.ts
+++ b/src/__tests__/hostNativeBoundary.test.ts
@@ -1,0 +1,270 @@
+import { DateTime } from 'luxon'
+import { describe, expect, it } from 'vitest'
+import trutoJsonata from '../index'
+import { toJsonataUrl } from '../functions/parseUrl'
+
+/**
+ * The JSONata-2.0-compatible host boundary: `trutoJsonata(...).evaluate()`
+ * mirrors native inputs (so expressions can read URL/Response/Blob/File/
+ * ArrayBuffer fields under JSONata 2.2's own-property-only lookup) and unwraps
+ * the JSONata-safe native wrappers out of the result (so callers get real
+ * instances back). These tests lock in the behaviour that lets host apps upgrade
+ * to 3.x by only bumping the version — no per-call-site adaptation.
+ */
+
+describe('host boundary — output unwrapping (result → real natives)', () => {
+  it('$jsonToParquet returns a real ArrayBuffer, not a wrapper', async () => {
+    const result = await trutoJsonata('$jsonToParquet(rows)').evaluate({
+      rows: [{ id: 1 }, { id: 2 }],
+    })
+    expect(result).toBeInstanceOf(ArrayBuffer)
+    expect((result as ArrayBuffer).byteLength).toBeGreaterThan(8)
+  })
+
+  it('$blob returns a real Blob', async () => {
+    const result = await trutoJsonata(
+      '$blob("hello", {"type": "text/plain"})'
+    ).evaluate({})
+    expect(result).toBeInstanceOf(Blob)
+    expect(await (result as Blob).text()).toBe('hello')
+  })
+
+  it('$parseUrl returns a real URL (round-trips via the native symbol)', async () => {
+    const result = await trutoJsonata('$parseUrl(u)').evaluate({
+      u: 'https://api.example.com/files/doc.pdf?q=1',
+    })
+    expect(result).toBeInstanceOf(URL)
+    expect((result as URL).pathname).toBe('/files/doc.pdf')
+    expect((result as URL).searchParams.get('q')).toBe('1')
+  })
+
+  it('$dtFromIso returns a real Luxon DateTime', async () => {
+    const result = await trutoJsonata('$dtFromIso(iso)').evaluate({
+      iso: '2024-01-15T00:00:00.000Z',
+    })
+    expect(DateTime.isDateTime(result)).toBe(true)
+    expect((result as DateTime).year).toBe(2024)
+  })
+
+  it('unwraps a wrapper nested inside a returned object', async () => {
+    const result = (await trutoJsonata(
+      '{ "file": $blob("x", {"type": "text/plain"}), "count": 2 }'
+    ).evaluate({})) as { file: unknown; count: number }
+    expect(result.file).toBeInstanceOf(Blob)
+    expect(result.count).toBe(2)
+  })
+
+  it('unwraps a wrapper nested inside a returned array', async () => {
+    const result = (await trutoJsonata(
+      '[ $jsonToParquet([{"id": 1}]), "tail" ]'
+    ).evaluate({})) as unknown[]
+    expect(result[0]).toBeInstanceOf(ArrayBuffer)
+    expect(result[1]).toBe('tail')
+  })
+
+  it('unwrapped binary result survives structuredClone (DO-stub RPC boundary)', async () => {
+    // A wrapper carries function props (arrayBuffer/slice) that make
+    // structuredClone throw DataCloneError. Proving the clone succeeds proves
+    // the wrapper is gone.
+    const parquet = await trutoJsonata('$jsonToParquet([{"id": 1}])').evaluate(
+      {}
+    )
+    expect(() => structuredClone(parquet)).not.toThrow()
+    const blob = await trutoJsonata(
+      '$blob("hi", {"type": "text/plain"})'
+    ).evaluate({})
+    expect(() => structuredClone(blob)).not.toThrow()
+    const nested = await trutoJsonata(
+      '{ "bytes": $jsonToParquet([{"id": 1}]) }'
+    ).evaluate({})
+    expect(() => structuredClone(nested)).not.toThrow()
+  })
+
+  it('leaves plain JSON results untouched (identity preserved, zero-alloc)', async () => {
+    const result = await trutoJsonata('payload').evaluate({
+      payload: { a: 1, b: [2, 3], c: { d: 'e' } },
+    })
+    expect(result).toEqual({ a: 1, b: [2, 3], c: { d: 'e' } })
+  })
+
+  it('passes primitives / null / undefined through unchanged', async () => {
+    await expect(trutoJsonata('n').evaluate({ n: 42 })).resolves.toBe(42)
+    await expect(trutoJsonata('s').evaluate({ s: 'x' })).resolves.toBe('x')
+    await expect(trutoJsonata('missing').evaluate({})).resolves.toBeUndefined()
+    await expect(
+      trutoJsonata('$exists(x) ? x : null').evaluate({})
+    ).resolves.toBeNull()
+  })
+})
+
+describe('host boundary — input mirroring (native inputs become readable)', () => {
+  it('reads fields off a URL passed as a top-level input', async () => {
+    const input = { u: new URL('https://user@api.example.com:8080/p/q?tag=1') }
+    await expect(trutoJsonata('u.pathname').evaluate(input)).resolves.toBe(
+      '/p/q'
+    )
+    await expect(trutoJsonata('u.origin').evaluate(input)).resolves.toBe(
+      'https://api.example.com:8080'
+    )
+    await expect(
+      trutoJsonata('u.searchParams.get("tag")').evaluate(input)
+    ).resolves.toBe('1')
+  })
+
+  it('does not mutate the host URL input (copy-on-write)', async () => {
+    const url = new URL('https://a.com/p')
+    const input = { u: url }
+    await trutoJsonata('u.pathname').evaluate(input)
+    expect(input.u).toBe(url)
+    expect(input.u).toBeInstanceOf(URL)
+  })
+
+  it('reads status / ok / headers off a Response passed as input', async () => {
+    const input = {
+      r: new Response('body', {
+        status: 201,
+        statusText: 'Created',
+        headers: { 'content-type': 'application/json' },
+      }),
+    }
+    await expect(trutoJsonata('r.status').evaluate(input)).resolves.toBe(201)
+    await expect(trutoJsonata('r.ok').evaluate(input)).resolves.toBe(true)
+    await expect(
+      trutoJsonata('$lookup(r.headers, "content-type")').evaluate(input)
+    ).resolves.toBe('application/json')
+  })
+
+  it('reads Blob getters nested deep in the input, keeping it a real Blob', async () => {
+    const blob = new Blob(['hello'], { type: 'text/plain' })
+    const input = { body: { file: blob } }
+    await expect(trutoJsonata('body.file.size').evaluate(input)).resolves.toBe(
+      5
+    )
+    await expect(trutoJsonata('body.file.type').evaluate(input)).resolves.toBe(
+      'text/plain'
+    )
+    // same instance, still a usable Blob for host consumers (FormData/fetch/R2)
+    expect(input.body.file).toBe(blob)
+    expect(input.body.file).toBeInstanceOf(Blob)
+    const fd = new FormData()
+    expect(() => fd.append('f', input.body.file)).not.toThrow()
+  })
+
+  it('reads File name/lastModified and ArrayBuffer byteLength from input', async () => {
+    const file = new File(['data'], 'report.csv', {
+      type: 'text/csv',
+      lastModified: 1700000000000,
+    })
+    await expect(trutoJsonata('f.name').evaluate({ f: file })).resolves.toBe(
+      'report.csv'
+    )
+    await expect(
+      trutoJsonata('f.lastModified').evaluate({ f: file })
+    ).resolves.toBe(1700000000000)
+
+    const buf = new ArrayBuffer(16)
+    await expect(
+      trutoJsonata('data.byteLength').evaluate({ data: buf })
+    ).resolves.toBe(16)
+  })
+
+  it('mirrors natives passed via the bindings argument too', async () => {
+    const expr = trutoJsonata('$u.pathname')
+    await expect(
+      expr.evaluate({}, { u: new URL('https://a.com/deep/path') })
+    ).resolves.toBe('/deep/path')
+  })
+
+  it('leaves an already-mirrored URL input (toJsonataUrl shape) intact', async () => {
+    const wrapped = toJsonataUrl(new URL('https://a.com/pre?x=9'))
+    const input = { u: wrapped }
+    await expect(trutoJsonata('u.pathname').evaluate(input)).resolves.toBe(
+      '/pre'
+    )
+    await expect(
+      trutoJsonata('u.searchParams.get("x")').evaluate(input)
+    ).resolves.toBe('9')
+    expect(input.u).toBe(wrapped)
+  })
+})
+
+describe('host boundary — round trip', () => {
+  it('a URL echoed through an expression comes back as a real URL', async () => {
+    const result = await trutoJsonata('u').evaluate({
+      u: new URL('https://a.com/echo/path?k=v'),
+    })
+    expect(result).toBeInstanceOf(URL)
+    expect((result as URL).pathname).toBe('/echo/path')
+    expect((result as URL).searchParams.get('k')).toBe('v')
+  })
+})
+
+describe('host boundary — replicated backend scenarios', () => {
+  it('dynamic-pagination: reads url + response, returns a real-URL next page', async () => {
+    // Mirrors DynamicPagination.getCursorFromResponse: url + response mirrored
+    // in, a $parseUrl-built next url returned out as a real URL.
+    const expr = trutoJsonata(`{
+      "status": response.status,
+      "path": url.pathname,
+      "nextUrl": $parseUrl(url.href & "&cursor=abc")
+    }`)
+    const result = (await expr.evaluate({
+      url: new URL('https://api.example.com/items?page=1'),
+      response: new Response('{}', { status: 200 }),
+    })) as { status: number; path: string; nextUrl: unknown }
+    expect(result.status).toBe(200)
+    expect(result.path).toBe('/items')
+    expect(result.nextUrl).toBeInstanceOf(URL)
+    expect((result.nextUrl as URL).searchParams.get('cursor')).toBe('abc')
+    expect((result.nextUrl as URL).searchParams.get('page')).toBe('1')
+  })
+
+  it('cursor built from $dtFromIso comes back as a real DateTime (not "[object Object]")', async () => {
+    // Mirrors the DynamicPagination cursor path that TextEncoder-encodes the
+    // result: a wrapper would encode to "[object Object]".
+    const result = await trutoJsonata('$dtFromIso(body.created_at)').evaluate({
+      body: { created_at: '2024-06-15T00:00:00.000Z' },
+    })
+    expect(DateTime.isDateTime(result)).toBe(true)
+    expect((result as DateTime).toISODate()).toBe('2024-06-15')
+  })
+
+  it('raw request body: $getArrayBuffer result is real bytes, not a stringified wrapper', async () => {
+    const result = await trutoJsonata(
+      '$getArrayBuffer($blob(body.text, {"type": "text/plain"}))'
+    ).evaluate({ body: { text: 'payload-bytes' } })
+    expect(result).toBeInstanceOf(ArrayBuffer)
+    expect(new TextDecoder().decode(result as ArrayBuffer)).toBe(
+      'payload-bytes'
+    )
+  })
+})
+
+describe('host boundary — evaluate interop (registerFunction / callback / echo)', () => {
+  it('a function registered after trutoJsonata() is visible to the wrapped evaluate', async () => {
+    // The backend registers per-eval helpers (e.g. $documentParserApiKey) on
+    // the expression AFTER trutoJsonata() and before evaluate(); patching
+    // evaluate must not shadow registerFunction or the environment it mutates.
+    const expr = trutoJsonata('$greet(name)')
+    expr.registerFunction('greet', (n: string) => `hi ${n}`)
+    await expect(expr.evaluate({ name: 'ada' })).resolves.toBe('hi ada')
+  })
+
+  it('supports the callback form of evaluate and unwraps the callback value', async () => {
+    const result = await new Promise((resolve, reject) => {
+      trutoJsonata('$jsonToParquet(rows)').evaluate(
+        { rows: [{ id: 1 }] },
+        undefined,
+        (err: unknown, value: unknown) => (err ? reject(err) : resolve(value))
+      )
+    })
+    expect(result).toBeInstanceOf(ArrayBuffer)
+  })
+
+  it('a real native echoed from input returns the same instance (no double-processing)', async () => {
+    const blob = new Blob(['x'], { type: 'text/plain' })
+    const result = await trutoJsonata('b').evaluate({ b: blob })
+    expect(result).toBe(blob)
+    expect(result).toBeInstanceOf(Blob)
+  })
+})

--- a/src/functions/deepUnwrapNative.ts
+++ b/src/functions/deepUnwrapNative.ts
@@ -1,0 +1,48 @@
+import { isArray, isPlainObject } from 'lodash-es'
+import { unwrapNative } from './unwrapNative'
+
+/**
+ * Recursively swap JSONata-safe native wrappers (from $blob, $jsonToParquet,
+ * $parseUrl, $dtFromIso, …) back for the real Blob/ArrayBuffer/URL/DateTime they
+ * box, so a result survives instanceof, structuredClone and JSON.stringify once
+ * it leaves JSONata. Copy-on-write — plain-JSON results pass through untouched.
+ */
+function deepUnwrapNative<T = unknown>(value: T): T {
+  const unwrapped = unwrapNative(value)
+  if (unwrapped !== value) {
+    // a wrapper — hand back the raw native, don't walk its method props
+    return unwrapped as T
+  }
+  if (isArray(value)) {
+    const items = value as unknown[]
+    let out: unknown[] | null = null
+    for (let i = 0; i < items.length; i++) {
+      const next = deepUnwrapNative(items[i])
+      if (!out && next !== items[i]) {
+        out = items.slice(0, i)
+      }
+      if (out) out.push(next)
+    }
+    return (out ?? value) as T
+  }
+  if (isPlainObject(value)) {
+    const record = value as Record<string, unknown>
+    const keys = Object.keys(record)
+    let out: Record<string, unknown> | null = null
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      const next = deepUnwrapNative(record[key])
+      if (!out && next !== record[key]) {
+        out = {}
+        for (let j = 0; j < i; j++) {
+          out[keys[j]] = record[keys[j]]
+        }
+      }
+      if (out) out[key] = next
+    }
+    return (out ?? value) as T
+  }
+  return value
+}
+
+export default deepUnwrapNative

--- a/src/functions/jsonataSafeResponse.ts
+++ b/src/functions/jsonataSafeResponse.ts
@@ -1,0 +1,30 @@
+/**
+ * Plain read-only mirror of a fetch Response for JSONata inputs — JSONata 2.2
+ * can't read a live Response's prototype getters. Headers flatten to a plain
+ * object; no body methods and no round-trip (the body is already consumed).
+ */
+function jsonataSafeResponse(response: Response) {
+  // structural cast: the DOM and Workers Response types declare `.type` differently
+  const r = response as unknown as {
+    status: number
+    statusText: string
+    ok: boolean
+    redirected: boolean
+    type: string
+    bodyUsed: boolean
+    url: string
+    headers: { entries(): Iterable<[string, string]> }
+  }
+  return {
+    status: r.status,
+    statusText: r.statusText,
+    ok: r.ok,
+    redirected: r.redirected,
+    type: r.type,
+    bodyUsed: r.bodyUsed,
+    url: r.url,
+    headers: Object.fromEntries(r.headers.entries()),
+  }
+}
+
+export default jsonataSafeResponse

--- a/src/functions/mirrorNativeInput.ts
+++ b/src/functions/mirrorNativeInput.ts
@@ -1,0 +1,94 @@
+import { isArray, isPlainObject } from 'lodash-es'
+import jsonataSafeResponse from './jsonataSafeResponse'
+import { toJsonataUrl } from './parseUrl'
+import { unwrapNative } from './unwrapNative'
+
+const STAMPED = Symbol('jsonataNativePropsStamped')
+
+// Own + enumerable so JSONata 2.2 can read it; configurable so re-stamping never
+// throws. Shadows the identical prototype getter — the value stays a real native.
+function stampOwnProp(target: object, name: string, value: unknown) {
+  Object.defineProperty(target, name, {
+    value,
+    enumerable: true,
+    configurable: true,
+  })
+}
+
+// Mirror a Blob/File/ArrayBuffer's getters as own props, in place, so
+// `body.file.name` / `data.size` / `buf.byteLength` work under JSONata 2.2.
+function stampNativeInstance(node: Blob | ArrayBuffer) {
+  if ((node as unknown as Record<symbol, unknown>)[STAMPED]) {
+    return
+  }
+  if (node instanceof Blob) {
+    stampOwnProp(node, 'size', node.size)
+    stampOwnProp(node, 'type', node.type)
+    if (typeof File !== 'undefined' && node instanceof File) {
+      stampOwnProp(node, 'name', node.name)
+      stampOwnProp(node, 'lastModified', node.lastModified)
+    }
+  } else {
+    stampOwnProp(node, 'byteLength', node.byteLength)
+  }
+  Object.defineProperty(node, STAMPED, { value: true })
+}
+
+/**
+ * Make native inputs readable by JSONata 2.2 expressions (which only see own
+ * properties): stamp Blob/File/ArrayBuffer in place, swap URL → the $parseUrl
+ * shape (round-trips back to a real URL on the way out) and Response → a plain
+ * mirror. Copy-on-write; already-wrapped values and opaque host objects
+ * (Headers, Map, DateTime, …) are left alone.
+ */
+function mirrorNativeInput<T>(value: T): T {
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+  // already a JSONata-safe wrapper: readable as-is, don't walk its methods
+  if (unwrapNative(value) !== value) {
+    return value
+  }
+  if (value instanceof Blob || value instanceof ArrayBuffer) {
+    stampNativeInstance(value)
+    return value
+  }
+  if (value instanceof URL) {
+    return toJsonataUrl(value) as unknown as T
+  }
+  if (typeof Response !== 'undefined' && value instanceof Response) {
+    return jsonataSafeResponse(value) as unknown as T
+  }
+  if (isArray(value)) {
+    const items = value as unknown[]
+    let out: unknown[] | null = null
+    for (let i = 0; i < items.length; i++) {
+      const next = mirrorNativeInput(items[i])
+      if (!out && next !== items[i]) {
+        out = items.slice(0, i)
+      }
+      if (out) out.push(next)
+    }
+    return (out ?? value) as T
+  }
+  if (isPlainObject(value)) {
+    const record = value as Record<string, unknown>
+    const keys = Object.keys(record)
+    let out: Record<string, unknown> | null = null
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      const next = mirrorNativeInput(record[key])
+      if (!out && next !== record[key]) {
+        out = {}
+        for (let j = 0; j < i; j++) {
+          out[keys[j]] = record[keys[j]]
+        }
+      }
+      if (out) out[key] = next
+    }
+    return (out ?? value) as T
+  }
+  return value
+}
+
+export default mirrorNativeInput

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,36 @@
 import jsonata, { Expression } from 'jsonata'
 import registerJsonataExtensions from './registerJsonataExtensions'
+import deepUnwrapNative from './functions/deepUnwrapNative'
+import mirrorNativeInput from './functions/mirrorNativeInput'
+
+type EvaluateCallback = (err: unknown, value: unknown) => void
 
 export default function trutoJsonata(expression: string): Expression {
-  return registerJsonataExtensions(jsonata(expression))
+  const expr = registerJsonataExtensions(jsonata(expression))
+  const evaluate = expr.evaluate.bind(expr)
+
+  // JSONata 2.2 only reads own properties and boxes native returns in wrappers.
+  // Mirror native inputs (URL/Response/File/Blob/ArrayBuffer) so expressions can
+  // read them, then unwrap the wrappers out of the result so callers get real
+  // instances back. Lets a host upgrade by only bumping the version.
+  function boundEvaluate(
+    input: unknown,
+    bindings?: Record<string, unknown>,
+    callback?: EvaluateCallback
+  ): Promise<unknown> | void {
+    const safeInput = mirrorNativeInput(input)
+    const safeBindings =
+      bindings === undefined ? undefined : mirrorNativeInput(bindings)
+    if (typeof callback === 'function') {
+      return evaluate(safeInput, safeBindings, (err: unknown, value: unknown) =>
+        callback(err, err ? value : deepUnwrapNative(value))
+      )
+    }
+    return Promise.resolve(evaluate(safeInput, safeBindings)).then(value =>
+      deepUnwrapNative(value)
+    )
+  }
+
+  expr.evaluate = boundEvaluate as unknown as Expression['evaluate']
+  return expr
 }
-
-// Native values returned by custom functions (ArrayBuffer, Blob, ReadableStream,
-// DepGraph, luxon DateTime, URL) are boxed in JSONata-safe wrappers so they
-// survive JSONata 2.2 evaluation. Consumers that need the real native value
-// back — e.g. the Truto worker uploading `$jsonToParquet(...)` bytes to S3/GCS —
-// must unwrap the evaluation result with these helpers.
-export {
-  unwrapNative,
-  unwrapArrayBuffer,
-  unwrapBlob,
-  unwrapReadableStream,
-  unwrapDepGraph,
-  unwrapDateTime,
-  unwrapUrl,
-} from './functions/unwrapNative'
-
-// Inverse direction: hosts that pass a native URL *into* an evaluation input
-// need the same JSONata-safe shape $parseUrl produces (JSONata 2.2+ cannot
-// read prototype getters, so a raw URL instance is opaque to expressions).
-export { toJsonataUrl } from './functions/parseUrl'


### PR DESCRIPTION
## What & why

JSONata 2.2 (shipped in truto-jsonata 3.0) changed two things for native values crossing an expression:

1. **Property lookup is own-property-only** → `url.pathname` / `response.status` / `body.file.name` read as `undefined` inside expressions.
2. **Custom functions box their native returns** (`$parseUrl`, `$blob`, `$jsonToParquet`, `$dtFromIso`, `$getArrayBuffer`, `$teeStream`, …) — the wrapper, once it leaves JSONata, fails `instanceof`, breaks `structuredClone` (function props → `DataCloneError` across Durable Object stubs), and serialises to `"[object Object]"`.

Until now every host had to adapt at each `.evaluate()` site (the Truto worker did this at ~24 sites + 3 helper files). This moves that compatibility shim **into the library's own boundary**, so hosts upgrade by only bumping the version — no per-call-site changes.

## How

`trutoJsonata(expr).evaluate(input, bindings)` now:

- **mirrors native inputs** (`functions/mirrorNativeInput`): stamps `Blob`/`File`/`ArrayBuffer` own-property mirrors in place (identity preserved — it stays a real native for `instanceof`/FormData/fetch/R2), replaces `URL` → `toJsonataUrl` (round-trips back out via the `NATIVE_URL` symbol) and `Response` → a plain read-only mirror. Copy-on-write: nothing is allocated for plain-JSON input.
- **unwraps native results** (`functions/deepUnwrapNative`, moved out of the host): copy-on-write recursion over plain objects/arrays that swaps any wrapper for its real native (checks `unwrapNative` first, so it never walks a wrapper's method props).

Implemented by wrapping `expr.evaluate` (jsonata's `Expression` is an unfrozen object literal; `assign`/`registerFunction`/`ast` are left intact — `registerFunction`-after-`trutoJsonata()` still works, which the host relies on). The wrapped `evaluate` is the package's **only** public export — the `unwrapNative*` / `toJsonataUrl` helpers stay internal (they were exported in 3.0.x only for the now-reverted host adaptation, which was never deployed).

## Tests

- 23 new boundary tests: input mirroring (URL/Response top-level, Blob/File/ArrayBuffer nested), output unwrapping, `structuredClone` survival, URL round-trip, replicated pagination/raw-body scenarios, and `registerFunction`/callback interop.
- Full suite **553 green** (530 pre-existing tests untouched); `tsc`, `bun build`, and `tsc` type-emit all clean.

## Compat / rollout notes

- **Semver `3.0.4` (patch off the published `3.0.3`).** This restores the raw-native behaviour hosts had before the 3.0.x wrapper era, so a host jumping 2.0.x → 3.0.4 (the Truto worker) is seamless. The only behaviour change vs 3.0.x is that a *bare* native result now serialises as the real native (e.g. a bare `$blob(...)` → `{}` instead of `{size,type}`); wrappers were always an internal mechanism, so no consumer should depend on that.
- **No silent upgrades.** All known consumers pin exact versions (`envoy` `1.0.52`, backend); nothing picks up `3.0.4` without an explicit bump.
- **Coordination:** the backend PR (`trutohq/truto` → `chore/upgrade-truto-jsonata-3.0.0`) drops its entire adaptation and points at `3.0.4`. **Merge + publish this first**, then the backend can `yarn install` to resolve `3.0.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
