### PR TITLE
fix: clear qs and lodash-es Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "picomatch": "npm:picomatch@4.0.4",
     "postcss": "npm:postcss@8.5.15",
     "langsmith": "npm:langsmith@0.7.3",
-    "uuid": "npm:uuid@11.1.1"
+    "uuid": "npm:uuid@11.1.1",
+    "qs": "npm:qs@6.15.2",
+    "lodash-es": "npm:lodash-es@4.18.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20241018.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2538,12 +2538,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@4.17.23:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
-  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
-
-lodash-es@4.18.1:
+lodash-es@4.17.23, lodash-es@4.18.1, "lodash-es@npm:lodash-es@4.18.1":
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
   integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
@@ -2876,14 +2871,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
-  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
-  dependencies:
-    side-channel "^1.1.0"
-
-qs@6.15.2:
+qs@6.15.0, qs@6.15.2, "qs@npm:qs@6.15.2":
   version "6.15.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
   integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==


### PR DESCRIPTION
## Summary
- Add yarn `resolutions` for `qs@6.15.2` and `lodash-es@4.18.1` so the nested `truto-jsonata-2-0-1` test pin no longer installs vulnerable transitive copies.
- Leaves `jsonata@2.0.6` under that pin intact (needed by `legacy201Compatibility`); Dependabot alert #67 dismissed as tolerable risk since the published package uses `jsonata@2.2.1`.

## Test plan
- [x] `yarn test src/__tests__/legacy201Compatibility.test.ts --run` (62/62)
- [ ] Confirm Dependabot alerts #48, #50, #60 auto-close after merge
- [ ] Confirm alert #67 stays dismissed