### PR TITLE
fix(deps): patch Sprinto advisories (@truto/truto-jsonata@3.0.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "langsmith": "npm:langsmith@0.7.3",
     "uuid": "npm:uuid@11.1.1",
     "qs": "npm:qs@6.15.2",
-    "lodash-es": "npm:lodash-es@4.18.1",
-    "jsonata": "2.2.1"
+    "lodash-es": "npm:lodash-es@4.18.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20241018.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -53,14 +53,15 @@
     "yarn": "1.22.22"
   },
   "resolutions": {
-    "brace-expansion": "npm:brace-expansion@1.1.15",
+    "brace-expansion": "npm:brace-expansion@1.1.18",
     "vite": "npm:vite@6.4.3",
     "picomatch": "npm:picomatch@4.0.4",
-    "postcss": "npm:postcss@8.5.15",
+    "postcss": "npm:postcss@8.5.23",
     "langsmith": "npm:langsmith@0.7.3",
     "uuid": "npm:uuid@11.1.1",
     "qs": "npm:qs@6.15.2",
-    "lodash-es": "npm:lodash-es@4.18.1"
+    "lodash-es": "npm:lodash-es@4.18.1",
+    "jsonata": "2.2.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20241018.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,7 +2407,12 @@ json5@^2.2.1, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonata@2.0.6, jsonata@2.2.1:
+jsonata@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.0.6.tgz#1187ec97f4662d6857b1cc40770f3ea61345d04c"
+  integrity sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==
+
+jsonata@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.2.1.tgz#91d706cdae700887158067beebb8e60a475d74e0"
   integrity sha512-xd1uwUrKeIcJbsWhaoS3qAX4Ea8m0Mw0G5nlnAQvPT7TbZ5qaPdzBVTQia9KfyuyQm+nenfyjvzUDTRYHsC2sw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,10 +1707,10 @@ baseline-browser-mapping@^2.10.38:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz#f372c8eb36ff4ad0b5e7ae467014abef124554ba"
   integrity sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==
 
-brace-expansion@^1.1.7, brace-expansion@^5.0.5, "brace-expansion@npm:brace-expansion@1.1.15":
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+brace-expansion@^1.1.7, brace-expansion@^5.0.5, "brace-expansion@npm:brace-expansion@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -2407,12 +2407,7 @@ json5@^2.2.1, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonata@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.0.6.tgz#1187ec97f4662d6857b1cc40770f3ea61345d04c"
-  integrity sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==
-
-jsonata@2.2.1:
+jsonata@2.0.6, jsonata@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.2.1.tgz#91d706cdae700887158067beebb8e60a475d74e0"
   integrity sha512-xd1uwUrKeIcJbsWhaoS3qAX4Ea8m0Mw0G5nlnAQvPT7TbZ5qaPdzBVTQia9KfyuyQm+nenfyjvzUDTRYHsC2sw==
@@ -2646,10 +2641,10 @@ n-gram@^2.0.0:
   resolved "https://registry.yarnpkg.com/n-gram/-/n-gram-2.0.2.tgz#e544a7dffefc49c22d898b2f491e787941b3a2ba"
   integrity sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==
 
-nanoid@^3.3.12:
-  version "3.3.15"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.15.tgz#36c490fad8c6e86c824c940dfdde999b69ed4316"
-  integrity sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==
+nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2835,12 +2830,12 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.5.3, "postcss@npm:postcss@8.5.15":
-  version "8.5.15"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
-  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
+postcss@^8.5.3, "postcss@npm:postcss@8.5.23":
+  version "8.5.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
+  integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## Summary
Dependency security remediation only — no application logic changed.

| Package | From | To | Notes |
|---|---|---|---|
| `brace-expansion` (resolution) | 1.1.15 | **1.1.18** | |
| `postcss` (resolution) | 8.5.15 | **8.5.23** | |

### jsonata note
Sprinto also flagged `jsonata@2.0.6`. The **published** package already depends on `jsonata@2.2.1`. The 2.0.6 copy exists only because the `legacy201Compatibility` suite installs published `@truto/truto-jsonata@2.0.1` as an oracle. Forcing `jsonata@2.2.1` via resolutions breaks that oracle (29 failures). Left as-is on purpose.

## Test plan
- [x] `yarn vitest run` legacy + jsonata22 + wrappers compat suites pass after fix
- [ ] Confirm Sprinto brace-expansion / postcss advisories clear after merge