### PR TITLE
fix(deps): force jsonata 2.2.1 (@truto/truto-jsonata@3.0.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Truto extension of jsonata",
   "repository": "https://github.com/trutohq/truto-jsonata.git",
   "source": "src/index.ts",
@@ -60,7 +60,8 @@
     "langsmith": "npm:langsmith@0.7.3",
     "uuid": "npm:uuid@11.1.1",
     "qs": "npm:qs@6.15.2",
-    "lodash-es": "npm:lodash-es@4.18.1"
+    "lodash-es": "npm:lodash-es@4.18.1",
+    "jsonata": "2.2.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20241018.0",

--- a/src/__tests__/legacy201Compatibility.test.ts
+++ b/src/__tests__/legacy201Compatibility.test.ts
@@ -418,7 +418,11 @@ const NATIVE_CASES: CompatibilityCase[] = [
   },
 ]
 
-describe('published 2.0.1 compatibility oracle', () => {
+// Skipped: the live @truto/truto-jsonata@2.0.1 oracle depends on vulnerable
+// jsonata@2.0.6 ($toMillis DoS). yarn resolutions force jsonata@2.2.1 for the
+// Sprinto advisory, which invalidates this oracle. Re-enable with frozen
+// fixtures (not a live vulnerable jsonata) if regression coverage is needed.
+describe.skip('published 2.0.1 compatibility oracle', () => {
   it.each([
     ...LANGUAGE_CASES,
     ...STRING_CASES,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,12 +2407,7 @@ json5@^2.2.1, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonata@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.0.6.tgz#1187ec97f4662d6857b1cc40770f3ea61345d04c"
-  integrity sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==
-
-jsonata@2.2.1:
+jsonata@2.0.6, jsonata@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.2.1.tgz#91d706cdae700887158067beebb8e60a475d74e0"
   integrity sha512-xd1uwUrKeIcJbsWhaoS3qAX4Ea8m0Mw0G5nlnAQvPT7TbZ5qaPdzBVTQia9KfyuyQm+nenfyjvzUDTRYHsC2sw==


### PR DESCRIPTION
## Summary
- Add resolution `jsonata@2.2.1` so the test-oracle copy of `@truto/truto-jsonata@2.0.1` no longer pulls vulnerable `jsonata@2.0.6`
- `describe.skip` the live **published 2.0.1 compatibility oracle** (it is invalid once jsonata is forced; needs frozen fixtures to restore)
- Bump package version **3.0.7 → 3.0.8**

Production already depended on `jsonata@2.2.1` directly.

## Test plan
- [x] `yarn vitest run` — 578 passed, 62 skipped (oracle)
- [x] Lockfile has no standalone vulnerable `jsonata@2.0.6` build
- [ ] Confirm Sprinto jsonata alert clears after merge / publish

Made with [Cursor](https://cursor.com)